### PR TITLE
Testing

### DIFF
--- a/src/styled-elem/constructors/pseudo.js
+++ b/src/styled-elem/constructors/pseudo.js
@@ -1,4 +1,4 @@
 import nested from './nested'
 
 export default (pseudo, ...rules) =>
-  nested(pseudo.split(',').map(p => '&:' + p).join(','), ...rules)
+  nested(pseudo.split(/\,\s?/).map(p => '&:' + p).join(','), ...rules)

--- a/src/styled-elem/constructors/test/pseudo.test.js
+++ b/src/styled-elem/constructors/test/pseudo.test.js
@@ -19,10 +19,9 @@ describe('pseudo', () => {
     expect(result.selector).toEqual('&:after,&:before')
   })
 
-  // TODO Fix this
-  it.skip('should handle spaces', () => {
+  it('should handle spaces', () => {
     const result = pseudo('after, before')
-    expect(result.selector).toEqual('&:after, &:before')
+    expect(result.selector).toEqual('&:after,&:before')
   })
 
   it('should add a rule', () => {

--- a/src/styled-elem/constructors/test/pseudo.test.js
+++ b/src/styled-elem/constructors/test/pseudo.test.js
@@ -1,0 +1,40 @@
+import expect from 'expect'
+import pseudo from '../pseudo'
+import NestedSelector from '../../models/NestedSelector.js'
+import ValidRuleSetChild from '../../models/ValidRuleSetChild.js'
+
+describe('pseudo', () => {
+  it('should return a NestedSelector', () => {
+    const result = pseudo('')
+    expect(result).toBeA(NestedSelector)
+  })
+
+  it('should prefix an ampersand', () => {
+    const result = pseudo('after')
+    expect(result.selector).toEqual('&:after')
+  })
+
+  it('should handle multiple selectors', () => {
+    const result = pseudo('after,before')
+    expect(result.selector).toEqual('&:after,&:before')
+  })
+
+  // TODO Fix this
+  it.skip('should handle spaces', () => {
+    const result = pseudo('after, before')
+    expect(result.selector).toEqual('&:after, &:before')
+  })
+
+  it('should add a rule', () => {
+    const rule = new ValidRuleSetChild()
+    const result = pseudo('after,before', rule)
+    expect(result.ruleSet.rules).toEqual([rule])
+  })
+
+  it('should multiple rules', () => {
+    const rule1 = new ValidRuleSetChild()
+    const rule2 = new ValidRuleSetChild()
+    const result = pseudo('after,before', rule1, rule2)
+    expect(result.ruleSet.rules).toEqual([rule1, rule2])
+  })
+})


### PR DESCRIPTION
- Tested the pseudo selector
- Fixed bug in pseudo constructor where valid notation 'before, after' threw an error in 06c277ce88167691fefd78006f0df49732dba46d
